### PR TITLE
Fixes trueValue value evaluation on BaseSessionDriver constructor

### DIFF
--- a/src/FireSessions/BaseSessionDriver.php
+++ b/src/FireSessions/BaseSessionDriver.php
@@ -45,7 +45,7 @@ abstract class BaseSessionDriver implements \SessionHandlerInterface
         $this->config = $config;
 
         $isPHP7 = version_compare(PHP_VERSION, '7.0.0') >= 0;
-        $isPHP7 && self::$trueValue = true && self::$falseValue = false;
+        $isPHP7 && self::$trueValue = true && ((self::$falseValue = false) === false);
     }
 
     /**


### PR DESCRIPTION
**Problem Statement**

The constructor for `BaseSessionDriver` class evaluates the following code `$isPHP7 && self::$trueValue = true && self::$falseValue = false;` to `false` for variable `self::$trueValue`.
So when `Files` class calls the `open()` method, the return value for the function `self::true()` returns false, resulting on the session file and cookie not being created.

Tested on `PHP 7.4.30` using the `Files` driver using version `1.1-stable`

**Fix solution**
Changing the aforementioned evaluation code to `$isPHP7 && (self::$trueValue = true) && ((self::$falseValue = false) === false);` fixes the issue.